### PR TITLE
OpenShift GitOps scaffold for media services

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -1,0 +1,11 @@
+# OpenShift Homelab Manifests
+
+This directory contains all Kubernetes/OpenShift resources managed by Argo CD for the homelab cluster.
+
+Layout:
+
+- `base/` – common namespace, storage and other baseline resources.
+- `argocd/` – Argo CD AppProject and Application definitions.
+- `extras/` – future monitoring, certificates, external-dns, backup, logging, etc.
+
+All manifests are applied via GitOps; commit changes and Argo CD will keep the cluster in sync.

--- a/openshift/argocd/appproject-homelab.yaml
+++ b/openshift/argocd/appproject-homelab.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: homelab
+  namespace: openshift-gitops
+spec:
+  description: Homelab media services
+  destinations:
+    - namespace: media
+      server: https://kubernetes.default.svc
+  sourceRepos:
+    - '*'
+  clusterResourceWhitelist:
+    - group: "*"
+      kind: "*"

--- a/openshift/argocd/apps/jellyfin.yaml
+++ b/openshift/argocd/apps/jellyfin.yaml
@@ -1,0 +1,43 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: jellyfin
+  namespace: openshift-gitops
+spec:
+  project: homelab
+  source:
+    repoURL: https://k8s-at-home.com/charts/
+    chart: jellyfin
+    targetRevision: 10.0.0
+    helm:
+      values: |
+        env:
+          TZ: America/Chicago
+        image:
+          tag: latest
+        service:
+          type: ClusterIP
+        ingress:
+          enabled: true
+          hosts:
+            - host: jellyfin.homelab.lan
+              paths:
+                - /
+          annotations:
+            route.openshift.io/termination: edge
+        persistence:
+          config:
+            enabled: true
+            existingClaim: jellyfin-config
+          media:
+            enabled: true
+            existingClaim: media
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: media
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/openshift/argocd/apps/radarr.yaml
+++ b/openshift/argocd/apps/radarr.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: radarr
+  namespace: openshift-gitops
+spec:
+  project: homelab
+  source:
+    repoURL: https://k8s-at-home.com/charts/
+    chart: radarr
+    targetRevision: 15.0.0
+    helm:
+      values: |
+        env:
+          TZ: America/Chicago
+        image:
+          tag: latest
+        ingress:
+          enabled: true
+          hosts:
+            - host: radarr.homelab.lan
+              paths:
+                - /
+          annotations:
+            route.openshift.io/termination: edge
+        persistence:
+          config:
+            enabled: true
+            existingClaim: radarr-config
+          media:
+            enabled: true
+            existingClaim: media
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: media
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/openshift/argocd/apps/sonarr.yaml
+++ b/openshift/argocd/apps/sonarr.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sonarr
+  namespace: openshift-gitops
+spec:
+  project: homelab
+  source:
+    repoURL: https://k8s-at-home.com/charts/
+    chart: sonarr
+    targetRevision: 16.0.0
+    helm:
+      values: |
+        env:
+          TZ: America/Chicago
+        image:
+          tag: latest
+        ingress:
+          enabled: true
+          hosts:
+            - host: sonarr.homelab.lan
+              paths:
+                - /
+          annotations:
+            route.openshift.io/termination: edge
+        persistence:
+          config:
+            enabled: true
+            existingClaim: sonarr-config
+          media:
+            enabled: true
+            existingClaim: media
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: media
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/openshift/base/namespace-media.yaml
+++ b/openshift/base/namespace-media.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: media
+  labels:
+    istio-injection: disabled

--- a/openshift/base/pvcs.yaml
+++ b/openshift/base/pvcs.yaml
@@ -1,0 +1,49 @@
+# PersistentVolumeClaims for media services
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: media
+  namespace: media
+spec:
+  accessModes: ["ReadWriteMany"]
+  resources:
+    requests:
+      storage: 2Ti
+  storageClassName: nfs-storage
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jellyfin-config
+  namespace: media
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: nfs-storage
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: radarr-config
+  namespace: media
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: nfs-storage
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sonarr-config
+  namespace: media
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: nfs-storage


### PR DESCRIPTION
Adds initial OpenShift manifests under `openshift/` directory:
* Base namespace and PVCs for media services
* Argo CD AppProject and Applications for Jellyfin, Radarr, Sonarr

This sets up the homelab media stack via GitOps.
