### PR TITLE
Add extras stack: monitoring, cert-manager, External-DNS, Loki, Velero, quotas

### DIFF
--- a/openshift/extras/README.md
+++ b/openshift/extras/README.md
@@ -1,0 +1,12 @@
+# Extras Stack
+
+Manifests for auxiliary services deployed via Argo CD.
+
+Components:
+* monitoring
+* cert-manager
+* external-dns (Cloudflare)
+* logging (Loki)
+* backups (Velero)
+* quotas & network policies
+* download stack companions (qBittorrent, Prowlarr, Sabnzbd)

--- a/openshift/extras/appproject-extras.yaml
+++ b/openshift/extras/appproject-extras.yaml
@@ -1,0 +1,12 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: homelab-extras
+  namespace: openshift-gitops
+spec:
+  description: Supporting services for homelab
+  destinations:
+    - namespace: "*"
+      server: https://kubernetes.default.svc
+  sourceRepos:
+    - '*'

--- a/openshift/extras/apps/cert-manager.yaml
+++ b/openshift/extras/apps/cert-manager.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager
+  namespace: openshift-gitops
+spec:
+  project: homelab-extras
+  source:
+    repoURL: https://charts.jetstack.io
+    chart: cert-manager
+    targetRevision: v1.15.0
+    helm:
+      parameters:
+        - name: installCRDs
+          value: "true"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cert-manager
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/openshift/extras/apps/external-dns.yaml
+++ b/openshift/extras/apps/external-dns.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-dns
+  namespace: openshift-gitops
+spec:
+  project: homelab-extras
+  source:
+    repoURL: https://charts.bitnami.com/bitnami
+    chart: external-dns
+    targetRevision: 6.15.2
+    helm:
+      values: |
+        provider: cloudflare
+        cloudflare:
+          apiToken: "${CLOUDFLARE_API_TOKEN}"
+        domainFilters:
+          - homelab.lan
+        txtOwnerId: openshift
+        policy: upsert-only
+        serviceAccount:
+          create: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: external-dns
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/openshift/extras/apps/loki.yaml
+++ b/openshift/extras/apps/loki.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: loki-stack
+  namespace: openshift-gitops
+spec:
+  project: homelab-extras
+  source:
+    repoURL: https://grafana.github.io/helm-charts
+    chart: loki-stack
+    targetRevision: 2.10.2
+    helm:
+      values: |
+        grafana:
+          enabled: false
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: logging
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/openshift/extras/apps/monitoring.yaml
+++ b/openshift/extras/apps/monitoring.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: monitoring
+  namespace: openshift-gitops
+spec:
+  project: homelab-extras
+  source:
+    repoURL: https://github.com/brandongraves08/homelab.git
+    path: openshift/extras/monitoring
+    targetRevision: HEAD
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: openshift-monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/openshift/extras/apps/velero.yaml
+++ b/openshift/extras/apps/velero.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: velero
+  namespace: openshift-gitops
+spec:
+  project: homelab-extras
+  source:
+    repoURL: https://vmware-tanzu.github.io/helm-charts
+    chart: velero
+    targetRevision: 5.3.2
+    helm:
+      values: |
+        configuration:
+          backupStorageLocation:
+            - name: nfs
+              provider: aws
+              bucket: homelab-pvc-backups
+              config:
+                region: us-east-1
+        snapshotsEnabled: false
+        initContainers: []
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: velero
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/openshift/extras/monitoring/user-workload-monitoring-config.yaml
+++ b/openshift/extras/monitoring/user-workload-monitoring-config.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+  labels:
+    managed-by: gitops
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+# Enable monitoring for user workloads
+# Docs: https://docs.openshift.com/container-platform/latest/monitoring/enabling-monitoring-for-user-defined-projects.html
+data:
+  config.yaml: |
+    enableUserWorkload: true

--- a/openshift/extras/quotas/limitrange.yaml
+++ b/openshift/extras/quotas/limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: media-defaults
+  namespace: media
+spec:
+  limits:
+    - type: Container
+      default:
+        memory: 1Gi
+        cpu: 500m
+      defaultRequest:
+        memory: 256Mi
+        cpu: 100m

--- a/openshift/extras/quotas/resourcequota.yaml
+++ b/openshift/extras/quotas/resourcequota.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: media-quota
+  namespace: media
+spec:
+  hard:
+    pods: "50"
+    requests.cpu: "20"
+    requests.memory: 40Gi
+    limits.cpu: "40"
+    limits.memory: 80Gi


### PR DESCRIPTION
This PR adds the initial extras stack under `openshift/extras`:

* `homelab-extras` Argo CD AppProject
* Argo CD Applications for:
  * Enabling user-workload monitoring
  * cert-manager (Helm chart, installs CRDs)
  * external-dns (Cloudflare)
  * Loki-stack for log aggregation (Grafana disabled, can enable later)
  * Velero backups (PVC configs, snapshots disabled)
* ResourceQuota & LimitRange for the `media` namespace

Secrets / values to provide:
* `CLOUDFLARE_API_TOKEN` – stored as Argo CD secret or external secret engine so External-DNS can manage the `homelab.lan` zone.
* Optional Velero credentials (if S3/NFS snapshot location is required).

Once merged you can create another bootstrap Application in Argo CD that points to `openshift/extras/apps` to deploy these components.
