### PR TITLE
Add CoreDNS private DNS and comprehensive README; remove External-DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,181 +1,40 @@
-# 📦 Homelab GitOps Deployment with OpenShift + ArgoCD
+# Homelab on OpenShift
 
-Welcome to the Homelab GitOps repository! This project defines and manages a modern self-hosted media environment deployed on **Red Hat OpenShift** using **ArgoCD** for GitOps, and **Helm charts from TrueCharts** for application delivery.
+This repository contains **GitOps-managed** manifests for my self-hosted media homelab running on an OpenShift cluster.
 
----
+## Components
+| Category | Stack | Source Path |
+|----------|-------|-------------|
+| Media | Jellyfin, Radarr, Sonarr | `openshift/argocd/apps/` |
+| Storage | Synology NFS (`nfs-storage` SC) | `openshift/base/pvcs.yaml` |
+| GitOps | Red Hat OpenShift GitOps (Argo CD) | operator subscription (manual) |
+| Monitoring | User-workload monitoring, Grafana dashboards | `openshift/extras/monitoring` |
+| Logging | Loki stack | `openshift/extras/apps/loki.yaml` |
+| TLS | cert-manager (self-signed / future ACME) | `openshift/extras/apps/cert-manager.yaml` |
+| Backups | Velero (PVC configs) | `openshift/extras/apps/velero.yaml` |
+| DNS | **CoreDNS** internal zone `homelab.lan` → ingress | `openshift/extras/coredns/` |
+| Quotas | ResourceQuota & LimitRange | `openshift/extras/quotas/` |
 
-## 🏗️ Lab Overview
+## Network & DNS
+* Base domain: `homelab.lan` (private).
+* CoreDNS rewrites `*.homelab.lan` to the OpenShift ingress wildcard (`*.apps.$CLUSTER_DOMAIN`).
+* Unknown queries forward to home router `192.168.2.1`.
+* Service node ports: UDP 53 → 30553, TCP 53 → 30554. Point LAN DHCP DNS to any cluster node IP.
 
-This homelab consists of:
+## Bootstrap sequence
+1. **homelab-base** – applies namespace & PVCs (Argo CD Application).
+2. **openshift/argocd** – deploys media apps.
+3. **homelab-extras** – deploys monitoring, cert-manager, Loki, Velero, CoreDNS, quotas.
 
-| Component       | Description                                      |
-|----------------|--------------------------------------------------|
-| **OpenShift**   | Cluster platform (running on Proxmox VMs)        |
-| **ArgoCD**      | GitOps controller for declarative app delivery   |
-| **TrueCharts**  | OCI-based Helm charts for homelab apps           |
-| **Apps**        | Plex, Radarr, Sonarr, Sabnzbd, Overseerr         |
-| **Storage**     | Backed by NFS or hostPath PVCs                   |
-| **Git Source**  | This repo serves as the source of truth          |
-
----
-
-## 📂 Current Repo Structure
-
-```
-.
-├── README.md
-├── applications/           # ArgoCD Application definitions
-│   ├── plex.yaml
-│   ├── radarr.yaml
-│   ├── sonarr.yaml
-│   ├── sabnzbd.yaml
-│   ├── root-app.yaml     # Parent app that manages all apps
-│   └── routes-app.yaml    # Application to manage routes
-├── charts/
-│   └── values/           # Helm values for each application
-│       ├── plex-values.yaml
-│       ├── radarr-values.yaml
-│       ├── sonarr-values.yaml
-│       └── sabnzbd-values.yaml
-├── homelab-config/
-│   └── openshift/        # OpenShift cluster configuration
-│       ├── client-ca.crt
-│       └── kubeconfig
-├── routes/               # OpenShift Route definitions
-│   ├── plex.yaml
-│   ├── radarr.yaml
-│   ├── sonarr.yaml
-│   └── sabnzbd.yaml
-├── scripts/              # Utility scripts
-│   ├── validate.sh      # Linux validation script
-│   └── validate.ps1     # Windows validation script
-├── storage/              # PVC definitions
-│   └── pvc.yaml
-├── .gitignore            # Excludes sensitive files
-├── argocd.yaml           # ArgoCD instance definition
-├── credentials.md        # EXCLUDED FROM GIT - Local credentials
-└── windsurf.yaml         # Validation rules
-```
-
-```
-.
-├── applications/
-│   ├── plex.yaml
-│   ├── radarr.yaml
-│   ├── sonarr.yaml
-│   └── sabnzbd.yaml
-├── charts/
-│   └── values/
-│       ├── plex-values.yaml
-│       ├── radarr-values.yaml
-│       └── sonarr-values.yaml
-├── storage/
-│   └── pvc.yaml
-├── homelab-config/
-│   └── openshift/
-│       ├── client-ca.crt
-│       └── kubeconfig
-└── README.md
-```
-
-- **`applications/`**: ArgoCD `Application` CRs, one per app  
-- **`charts/values/`**: Helm values files for TrueCharts apps  
-- **`storage/`**: PVC definitions for config/media volumes  
-
----
-
-## 🚀 GitOps Deployment Flow
-
-1. OpenShift cluster is running on Proxmox with 3 nodes.
-2. ArgoCD is installed via OperatorHub in the `media` namespace.
-3. ArgoCD watches this repo for applications and values.
-4. Changes are committed to GitHub repository.
-5. ArgoCD detects changes and can sync applications manually or automatically.
-6. Each app is deployed from **TrueCharts' OCI Helm registry**.
-7. Persistent storage is mapped via PVCs in the `media` namespace.
-8. Networking is exposed via OpenShift Routes.
-
----
-
-## 🔁 Planned Applications
-
-| App       | Chart Source (OCI)                        | Helm Values Path                    |
-|-----------|-------------------------------------------|-------------------------------------|
-| Plex      | `oci://tccr.io/truecharts/plex`           | `charts/values/plex-values.yaml`   |
-| Radarr    | `oci://tccr.io/truecharts/radarr`         | `charts/values/radarr-values.yaml` |
-| Sonarr    | `oci://tccr.io/truecharts/sonarr`         | `charts/values/sonarr-values.yaml` |
-| Sabnzbd   | `oci://tccr.io/truecharts/sabnzbd`        | `charts/values/sabnzbd-values.yaml`|
-
----
-
-## ⚙️ Planned OpenShift Configuration
-
-- PVCs created for `/config` and `/data` per app
-- Optional SCC bindings or `anyuid` usage for media apps
-- Routes or NodePorts used to expose web interfaces
-
----
-
-## 💡 Windsurf Rule Ideas
-
-For Windsurf repo validation, consider rules such as:
-
-- `Ensure all ArgoCD applications point to HEAD or a semver tag`
-- `All charts must use persistent volumes`
-- `Warn if claimToken is not set for Plex`
-- `Validate Helm value files are named <app>-values.yaml`
-- `Ensure Route definitions exist for exposed services`
-
----
-
-## 📬 Contributions
-
-This project is intended for personal/homelab use. PRs welcome if they improve automation or compatibility for similar setups.
-
----
-
-## 🔄 GitOps Workflow Usage
-
-### Initial Setup
-
-1. Clone this repository to your local machine
-2. Push to your GitHub repository (public or private)
-3. Ensure ArgoCD has access to the repository
-4. Apply the root application to start syncing:
-   ```bash
-   oc apply -f applications/root-app.yaml
-   ```
-5. Log in to ArgoCD UI to monitor deployments
-
-### Making Changes
-
-1. Make changes to the appropriate files locally
-2. Run validation script to ensure compliance:
-   ```bash
-   # Linux/Mac
-   ./scripts/validate.sh
-   
-   # Windows
-   .\scripts\validate.ps1
-   ```
-3. Commit and push changes to GitHub
-4. Sync applications in ArgoCD UI (or configure auto-sync)
-
-### Accessing Services
-
-All services are exposed via OpenShift Routes. Access URLs can be found in the ArgoCD UI or by running:
+## Usage
 ```bash
-oc get routes -n media
+# Access Argo CD UI
+oc get route openshift-gitops-server -n openshift-gitops
+
+# Default app URLs (internal only)
+https://jellyfin.homelab.lan
+https://radarr.homelab.lan
+https://sonarr.homelab.lan
 ```
 
-## 🧪 Coming Soon
-
-- Monitoring with Prometheus/Grafana
-- Automatic Helm chart update detection with Renovate
-- Backup integration with Velero or Restic
-
----
-
-## 📎 License
-
-MIT License
+See individual directories for detailed configuration.

--- a/openshift/extras/apps/coredns.yaml
+++ b/openshift/extras/apps/coredns.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: coredns
+  namespace: openshift-gitops
+spec:
+  project: homelab-extras
+  source:
+    repoURL: https://github.com/brandongraves08/homelab.git
+    targetRevision: HEAD
+    path: openshift/extras/coredns
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: dns
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/openshift/extras/coredns/coredns-configmap.yaml
+++ b/openshift/extras/coredns/coredns-configmap.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: dns
+  labels:
+    app: coredns
+
+data:
+  Corefile: |
+    homelab.lan:53 {
+        errors
+        log
+        rewrite name regex (.*)\.homelab\.lan {1}.apps.$CLUSTER_DOMAIN
+        forward . 192.168.2.1
+        cache 30
+    }
+
+    .:53 {
+        errors
+        log
+        forward . 192.168.2.1
+        cache 30
+    }

--- a/openshift/extras/coredns/coredns-deployment.yaml
+++ b/openshift/extras/coredns/coredns-deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coredns
+  namespace: dns
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: coredns
+  template:
+    metadata:
+      labels:
+        app: coredns
+    spec:
+      containers:
+        - name: coredns
+          image: coredns/coredns:1.11.2
+          args: ["-conf", "/etc/coredns/Corefile"]
+          ports:
+            - containerPort: 53
+              protocol: UDP
+            - containerPort: 53
+              protocol: TCP
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/coredns
+      volumes:
+        - name: config-volume
+          configMap:
+            name: coredns

--- a/openshift/extras/coredns/coredns-service.yaml
+++ b/openshift/extras/coredns/coredns-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns
+  namespace: dns
+spec:
+  type: NodePort
+  ports:
+    - name: dns-udp
+      port: 53
+      protocol: UDP
+      targetPort: 53
+      nodePort: 30553
+    - name: dns-tcp
+      port: 53
+      protocol: TCP
+      targetPort: 53
+      nodePort: 30554
+  selector:
+    app: coredns

--- a/openshift/extras/coredns/kustomization.yaml
+++ b/openshift/extras/coredns/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - coredns-deployment.yaml
+  - coredns-service.yaml
+  - coredns-configmap.yaml


### PR DESCRIPTION
* Adds CoreDNS manifests under `openshift/extras/coredns` and Argo CD Application.
* Deletes `openshift/extras/apps/external-dns.yaml` (External-DNS no longer needed).
* Adds top-level `README.md` summarizing the full homelab stack and usage instructions.

CoreDNS forwards non-lab queries to `192.168.2.1` and rewrites `*.homelab.lan` to the OpenShift ingress wildcard.
