### PR TITLE
Expose CoreDNS on host port 53

### DIFF
--- a/openshift/extras/coredns/coredns-deployment.yaml
+++ b/openshift/extras/coredns/coredns-deployment.yaml
@@ -13,6 +13,8 @@ spec:
       labels:
         app: coredns
     spec:
+      hostNetwork: true
+      dnsPolicy: Default
       containers:
         - name: coredns
           image: coredns/coredns:1.11.2
@@ -20,8 +22,10 @@ spec:
           ports:
             - containerPort: 53
               protocol: UDP
+              hostPort: 53
             - containerPort: 53
               protocol: TCP
+              hostPort: 53
           volumeMounts:
             - name: config-volume
               mountPath: /etc/coredns


### PR DESCRIPTION
Patch CoreDNS deployment to use hostNetwork and hostPort 53 so home router can query DNS without custom port.
