### PR TITLE
Fix CoreDNS rewrite with ingress domain

### DIFF
--- a/openshift/extras/coredns/coredns-configmap.yaml
+++ b/openshift/extras/coredns/coredns-configmap.yaml
@@ -11,7 +11,7 @@ data:
     homelab.lan:53 {
         errors
         log
-        rewrite name regex (.*)\.homelab\.lan {1}.apps.$CLUSTER_DOMAIN
+        rewrite name regex (.*)\.homelab\.lan {1}.apps.openshift.thelab.lan
         forward . 192.168.2.1
         cache 30
     }


### PR DESCRIPTION
Update CoreDNS Corefile to rewrite *.homelab.lan to apps.openshift.thelab.lan, fixing REFUSED errors.