### PR TITLE
Fix homelab-extras Application path

### DIFF
--- a/openshift/bootstrap/homelab-extras.yaml
+++ b/openshift/bootstrap/homelab-extras.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     repoURL: https://github.com/brandongraves08/homelab.git
     targetRevision: HEAD
-    path: openshift/extras/apps
+    path: openshift/extras
   destination:
     server: https://kubernetes.default.svc
     namespace: openshift-gitops


### PR DESCRIPTION
Point homelab-extras root Application to openshift/extras so AppProject and child apps sync correctly.